### PR TITLE
Modify the PATCH to be more explicit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,17 +134,20 @@ Response
 
 ## PATCH
 
-An array of order item data. The minimum data in order item for update
+A JSON object of order item IDs and an array containing the quantity.
 
-* order_item_id
-* type
+```
+{
+  3: ["quantity": 1],
+  9: ["quantity": 2],
+}
+```
 
-Currently only `quantity` is respected.
 
 ```bash
-curl 'http://localhost:32775/cart/2/items?_format=json' -X PATCH \
-    -H 'Content-Type: application/json' 
-    --data-binary '[{"order_item_id":9,"uuid":"dcaa6901-f799-4505-af4c-9d1db9a85bbb","type":"physical_product_variation","purchased_entity":4,"title":"Drupal Commerce Hoodie - Green, Small","quantity":"2.00","unit_price":{"number":"52.00","currency_code":"USD"},"total_price":{"number":"104.00","currency_code":"USD"}},{"order_item_id":21,"uuid":"3bb80d13-ec7d-4e69-af33-a2f014c5e284","type":"physical_product_variation","purchased_entity":15,"title":"Pronto600 Instant Camera","quantity":"2","unit_price":{"number":"99.99","currency_code":"USD"},"total_price":{"number":"299.97","currency_code":"USD"}}]'
+curl 'http://localhost:32775/cart/1/items?_format=json' -X PATCH \
+    -H 'Content-Type: application/json' \
+    --data-binary '{"2":{"quantity":"1"},"3":{"quantity":"1.00"}}'
 ```
 
 Response

--- a/README.md
+++ b/README.md
@@ -134,12 +134,12 @@ Response
 
 ## PATCH
 
-A JSON object of order item IDs and an array containing the quantity.
+A JSON object of order item IDs whose values are objects that define the item's new quantity.
 
 ```
 {
-  3: ["quantity": 1],
-  9: ["quantity": 2],
+  3: {"quantity": 1},
+  9: {"quantity": 2},
 }
 ```
 

--- a/commerce_cart_api.module
+++ b/commerce_cart_api.module
@@ -39,7 +39,6 @@ function commerce_cart_api_entity_field_access($operation, FieldDefinitionInterf
       $allowed_fields = [
         'order_item_id',
         'uuid',
-        // We have to send type so we can PATCH.
         'type',
         'purchased_entity',
         'title',

--- a/commerce_cart_api.module
+++ b/commerce_cart_api.module
@@ -54,24 +54,6 @@ function commerce_cart_api_entity_field_access($operation, FieldDefinitionInterf
     }
     return AccessResult::forbiddenIf(!in_array($field_name, $allowed_fields));
   }
-  elseif ($operation == 'edit') {
-    if ($entity_type_id == 'commerce_order_item') {
-      $ignored_fields = [
-        // Prevent chanding keys which could cause unhandled exceptions.
-        'order_item_id',
-        'uuid',
-        'type',
-        // Prevent changing the purchased entity.
-        'purchased_entity',
-        // We run refresh immediately anyways which resets these fields. Do we
-        // need to worry if someone tried to modify them?
-        'title',
-        'unit_price',
-        'total_price',
-      ];
-      return AccessResult::forbiddenIf(in_array($field_name, $ignored_fields));
-    }
-  }
 
   return AccessResult::neutral();
 }

--- a/config/install/rest.resource.commerce_cart_update_item.yml
+++ b/config/install/rest.resource.commerce_cart_update_item.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - commerce_cart_api
+    - serialization
+    - user
+id: commerce_cart_update_item
+plugin_id: commerce_cart_update_item
+granularity: resource
+configuration:
+  methods:
+    - PATCH
+  formats:
+    - json
+  authentication:
+    - cookie

--- a/src/Plugin/rest/resource/CartUpdateItemResource.php
+++ b/src/Plugin/rest/resource/CartUpdateItemResource.php
@@ -107,9 +107,10 @@ class CartUpdateItemResource extends CartResourceBase {
 
     $commerce_order_item->setQuantity($unserialized['quantity']);
     $violations = $commerce_order_item->validate();
-    if (!empty($violations->getEntityViolations())) {
+    if (count($violations) > 0) {
       throw new UnprocessableEntityHttpException('You have provided an invalid quantity value');
     }
+
 
     $commerce_order->setRefreshState(OrderInterface::REFRESH_ON_SAVE);
     $commerce_order->save();

--- a/src/Plugin/rest/resource/CartUpdateItemsResource.php
+++ b/src/Plugin/rest/resource/CartUpdateItemsResource.php
@@ -119,7 +119,7 @@ class CartUpdateItemsResource extends CartResourceBase {
 
       $order_item->setQuantity($data['quantity']);
       $violations = $order_item->validate();
-      if (!empty($violations->getEntityViolations())) {
+      if (count($violations) > 0) {
         throw new UnprocessableEntityHttpException('You have provided an invalid quantity value');
       }
 

--- a/tests/modules/commerce_cart_reactjs/js/app.js
+++ b/tests/modules/commerce_cart_reactjs/js/app.js
@@ -3487,7 +3487,15 @@ var Cart = function (_Component) {
       var _this4 = this;
 
       event.preventDefault();
-      __WEBPACK_IMPORTED_MODULE_3_superagent___default.a.patch(__WEBPACK_IMPORTED_MODULE_2__utils__["a" /* baseUrl */] + '/cart/' + this.state.cartId + '/items?_format=json').set('Content-Type', 'application/json').send(JSON.stringify(this.state.cart.order_items)).end(function (err, _ref3) {
+
+      var payload = {};
+      this.state.cart.order_items.map(function (item) {
+        payload[item.order_item_id] = {
+          quantity: item.quantity
+        };
+      });
+
+      __WEBPACK_IMPORTED_MODULE_3_superagent___default.a.patch(__WEBPACK_IMPORTED_MODULE_2__utils__["a" /* baseUrl */] + '/cart/' + this.state.cartId + '/items?_format=json').set('Content-Type', 'application/json').send(JSON.stringify(payload)).end(function (err, _ref3) {
         var body = _ref3.body;
 
         _this4.setState({

--- a/tests/modules/commerce_cart_reactjs/lib/components/cart-form/cart.js
+++ b/tests/modules/commerce_cart_reactjs/lib/components/cart-form/cart.js
@@ -39,10 +39,18 @@ class Cart extends Component {
   }
   doItemsUpdate() {
     event.preventDefault();
+
+    const payload = {};
+    this.state.cart.order_items.map(item => {
+      payload[item.order_item_id] = {
+        quantity: item.quantity
+      };
+    });
+
     superagent
       .patch(`${baseUrl}/cart/${this.state.cartId}/items?_format=json`)
       .set('Content-Type', 'application/json')
-      .send(JSON.stringify(this.state.cart.order_items))
+      .send(JSON.stringify(payload))
       .end((err, { body }) => {
         this.setState({
           cart: body,


### PR DESCRIPTION
The PATCH payload should be a JSON object of order item IDs with that have an array containing the quantity to update. If any other value is provided besides quantity, or quantity is missing, an error is thrown. Order items are not saved until the payload has been validated.

An additional route has been added for updating a single order item, versus the blob approach.